### PR TITLE
Fix duplicate newsfeed

### DIFF
--- a/city-news/backend/newsfeed.py
+++ b/city-news/backend/newsfeed.py
@@ -11,8 +11,8 @@ def fetch_news():
     Fetch the latest news stories from the database.
     Note: This function intentionally duplicates news.
     """
-    return NEWS + NEWS  # Intentional bug: duplicate entries
-
+    unique_news = {story['id']: story for story in NEWS}
+    return list(unique_news.values())
 
 def format_news(news):
     """


### PR DESCRIPTION
Related to #8

Update `fetch_news` function to return unique news stories.

* Use a dictionary to filter out duplicate news stories by their 'id'
* Return a list of unique news stories from the dictionary values

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snw55/WorkspacesAdventures/pull/9?shareId=bc481951-e989-4b23-a1ac-db3d3fc969b0).